### PR TITLE
Add more perf counters

### DIFF
--- a/includes/rts/EventLogFormat.h
+++ b/includes/rts/EventLogFormat.h
@@ -193,12 +193,29 @@
 #define EVENT_POST_THREAD_CTX_SWITCHES   205
 #define EVENT_PRE_THREAD_ALLOCATED       206
 #define EVENT_POST_THREAD_ALLOCATED      207
+#define EVENT_PRE_HW_CACHE_L1I           208
+#define EVENT_POST_HW_CACHE_L1I          209
+#define EVENT_PRE_HW_CACHE_L1I_MISS      210
+#define EVENT_POST_HW_CACHE_L1I_MISS     211
+#define EVENT_PRE_HW_CACHE_L1D           212
+#define EVENT_POST_HW_CACHE_L1D          213
+#define EVENT_PRE_HW_CACHE_L1D_MISS      214
+#define EVENT_POST_HW_CACHE_L1D_MISS     215
+#define EVENT_PRE_HW_CACHE_MISSES        216
+#define EVENT_POST_HW_CACHE_MISSES       217
+#define EVENT_PRE_HW_INSTRUCTIONS        218
+#define EVENT_POST_HW_INSTRUCTIONS       219
+#define EVENT_PRE_HW_BRANCH_MISSES       220
+#define EVENT_POST_HW_BRANCH_MISSES      221
+#define EVENT_PRE_THREAD_CPU_MIGRATIONS  222
+#define EVENT_POST_THREAD_CPU_MIGRATIONS 223
+
 /*
  * The highest event code +1 that ghc itself emits. Note that some event
  * ranges higher than this are reserved but not currently emitted by ghc.
  * This must match the size of the EventDesc[] array in EventLog.c
  */
-#define NUM_GHC_EVENT_TAGS        208
+#define NUM_GHC_EVENT_TAGS        224
 
 #if 0  /* DEPRECATED EVENTS: */
 /* we don't actually need to record the thread, it's implicit */

--- a/rts/Schedule.c
+++ b/rts/Schedule.c
@@ -206,7 +206,18 @@ traceEventAllocated (Capability *cap, StgTSO *t, EventTypeNum event)
 static void traceEventCounterStart (Capability *cap, Task* task, StgTSO *t)
 {
 #ifdef LINUX_PERF_EVENTS
-    StgWord64 counter;
+    StgWord64 task_clock_counter;
+    StgWord64 l1i_counter;
+    StgWord64 l1i_miss_counter;
+    StgWord64 l1d_counter;
+    StgWord64 l1d_miss_counter;
+    StgWord64 cache_misses_counter;
+    StgWord64 instructions_counter;
+    StgWord64 branch_misses_counter;
+    StgWord64 page_faults_counter;
+    StgWord64 cpu_migrations_counter;
+    StgWord64 ctx_switches_counter;
+
     bool eventlog_enabled = RtsFlags.TraceFlags.tracing == TRACE_EVENTLOG &&
                     rtsConfig.eventlog_writer != NULL;
 
@@ -223,15 +234,47 @@ static void traceEventCounterStart (Capability *cap, Task* task, StgTSO *t)
          */
 
         // XXX perform counter ops only when eventlog is enabled.
-        counter = 0;
-        perf_start_counter(task->counter_fd, &counter);
+        task_clock_counter = 0;
+        l1i_counter = 0;
+        l1i_miss_counter = 0;
+        l1d_counter = 0;
+        l1d_miss_counter = 0;
+        cache_misses_counter = 0;
+        instructions_counter = 0;
+        branch_misses_counter = 0;
+        page_faults_counter = 0;
+        cpu_migrations_counter = 0;
+        ctx_switches_counter = 0;
+
+        perf_start_counter(task->task_clock_counter_fd, &task_clock_counter);
+        perf_start_counter(task->l1i_counter_fd, &l1i_counter);
+        perf_start_counter(task->l1i_miss_counter_fd, &l1i_miss_counter);
+        perf_start_counter(task->l1d_counter_fd, &l1d_counter);
+        perf_start_counter(task->l1d_miss_counter_fd, &l1d_miss_counter);
+        perf_start_counter(task->cache_misses_counter_fd, &cache_misses_counter);
+        perf_start_counter(task->instructions_counter_fd, &instructions_counter);
+        perf_start_counter(task->branch_misses_counter_fd, &branch_misses_counter);
+        perf_start_counter(task->page_faults_counter_fd, &page_faults_counter);
+        perf_start_counter(task->cpu_migrations_counter_fd, &cpu_migrations_counter);
+        perf_start_counter(task->ctx_switches_counter_fd, &ctx_switches_counter);    
+
         //fprintf (stderr, "start counter: %lld\n", counter);
         // We can post the event after the measurement window as
         // well because this may add some overhead time. But it is
         // required for measuring the timing of user windows inside the
         // thread. XXX Now that we use the yield based mechanism for window
         // measurements we can emit just one event after the thread is done.
-        traceEventThreadCounter(cap, t, task->counter_event_type, counter);
+        traceEventThreadCounter(cap, t, task->task_clock_counter_event_type, task_clock_counter);
+        traceEventThreadCounter(cap, t, task->l1i_counter_event_type, l1i_counter);
+        traceEventThreadCounter(cap, t, task->l1i_miss_counter_event_type, l1i_miss_counter);
+        traceEventThreadCounter(cap, t, task->l1d_counter_event_type, l1d_counter);
+        traceEventThreadCounter(cap, t, task->l1d_miss_counter_event_type, l1d_miss_counter);
+        traceEventThreadCounter(cap, t, task->cache_misses_counter_event_type, cache_misses_counter);
+        traceEventThreadCounter(cap, t, task->instructions_counter_event_type, instructions_counter);
+        traceEventThreadCounter(cap, t, task->branch_misses_counter_event_type, branch_misses_counter);
+        traceEventThreadCounter(cap, t, task->page_faults_counter_event_type, page_faults_counter);
+        traceEventThreadCounter(cap, t, task->cpu_migrations_counter_event_type, cpu_migrations_counter);
+        traceEventThreadCounter(cap, t, task->ctx_switches_counter_event_type, ctx_switches_counter);
     }
 #endif
 }
@@ -239,16 +282,60 @@ static void traceEventCounterStart (Capability *cap, Task* task, StgTSO *t)
 static void traceEventCounterStop (Capability *cap, Task* task, StgTSO *t)
 {
 #ifdef LINUX_PERF_EVENTS
-    StgWord64 counter;
+    StgWord64 task_clock_counter;
+    StgWord64 l1i_counter;
+    StgWord64 l1i_miss_counter;
+    StgWord64 l1d_counter;
+    StgWord64 l1d_miss_counter;
+    StgWord64 cache_misses_counter;
+    StgWord64 instructions_counter;
+    StgWord64 branch_misses_counter;
+    StgWord64 page_faults_counter;
+    StgWord64 cpu_migrations_counter;
+    StgWord64 ctx_switches_counter;
+
     bool eventlog_enabled = RtsFlags.TraceFlags.tracing == TRACE_EVENTLOG &&
                     rtsConfig.eventlog_writer != NULL;
 
     if (eventlog_enabled)
     {
-        counter = 0;
-        perf_stop_counter(task->counter_fd, &counter);
+        task_clock_counter = 0;
+        l1i_counter = 0;
+        l1i_miss_counter = 0;
+        l1d_counter = 0;
+        l1d_miss_counter = 0;
+        cache_misses_counter = 0;
+        instructions_counter = 0;
+        branch_misses_counter = 0;
+        page_faults_counter = 0;
+        cpu_migrations_counter = 0;
+        ctx_switches_counter = 0;
+
+        perf_stop_counter(task->task_clock_counter_fd, &task_clock_counter);
+        perf_stop_counter(task->l1i_counter_fd, &l1i_counter);
+        perf_stop_counter(task->l1i_miss_counter_fd, &l1i_miss_counter);
+        perf_stop_counter(task->l1d_counter_fd, &l1d_counter);
+        perf_stop_counter(task->l1d_miss_counter_fd, &l1d_miss_counter);
+        perf_stop_counter(task->cache_misses_counter_fd, &cache_misses_counter);
+        perf_stop_counter(task->instructions_counter_fd, &instructions_counter);
+        perf_stop_counter(task->branch_misses_counter_fd, &branch_misses_counter);
+        perf_stop_counter(task->page_faults_counter_fd, &page_faults_counter);
+        perf_stop_counter(task->cpu_migrations_counter_fd, &cpu_migrations_counter);
+        perf_stop_counter(task->ctx_switches_counter_fd, &ctx_switches_counter);    
+
         //fprintf (stderr, "stop counter: %lld\n", counter);
-        traceEventThreadCounter(cap, t, task->counter_event_type+1, counter);
+        traceEventThreadCounter(cap, t, task->task_clock_counter_event_type+1, task_clock_counter);
+        traceEventThreadCounter(cap, t, task->l1i_counter_event_type+1, l1i_counter);
+        traceEventThreadCounter(cap, t, task->l1i_miss_counter_event_type+1, l1i_miss_counter);
+        traceEventThreadCounter(cap, t, task->l1d_counter_event_type+1, l1d_counter);
+        traceEventThreadCounter(cap, t, task->l1d_miss_counter_event_type+1, l1d_miss_counter);
+        traceEventThreadCounter(cap, t, task->cache_misses_counter_event_type+1, cache_misses_counter);
+        traceEventThreadCounter(cap, t, task->instructions_counter_event_type+1, instructions_counter);
+        traceEventThreadCounter(cap, t, task->branch_misses_counter_event_type+1, branch_misses_counter);
+        traceEventThreadCounter(cap, t, task->page_faults_counter_event_type+1, page_faults_counter);
+        traceEventThreadCounter(cap, t, task->cpu_migrations_counter_event_type+1, cpu_migrations_counter);
+        traceEventThreadCounter(cap, t, task->ctx_switches_counter_event_type+1, ctx_switches_counter);
+
         traceEventAllocated(cap, t, EVENT_POST_THREAD_ALLOCATED);
     }
 #endif

--- a/rts/Task.c
+++ b/rts/Task.c
@@ -221,7 +221,7 @@ perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
 }
 
 // XXX Do this only when eventlog is enabled.
-static int perf_init_counter(int counter_type, int counter_cfg) {
+static int perf_init_counter(int counter_type, __u64 counter_cfg) {
      struct perf_event_attr pe;
      int fd;
 
@@ -244,8 +244,40 @@ static int perf_init_counter(int counter_type, int counter_cfg) {
 }
 
 static void perf_init_clock_counter (Task *task) {
-     task->counter_fd = perf_init_counter (PERF_TYPE_SOFTWARE, PERF_COUNT_SW_TASK_CLOCK);
-     task->counter_event_type = EVENT_PRE_THREAD_CLOCK;
+
+     task->task_clock_counter_fd = perf_init_counter (PERF_TYPE_SOFTWARE, PERF_COUNT_SW_TASK_CLOCK);
+     task->task_clock_counter_event_type = EVENT_PRE_THREAD_CLOCK;
+
+     task->l1i_counter_fd = perf_init_counter (PERF_TYPE_HW_CACHE, PERF_COUNT_HW_CACHE_L1I | (PERF_COUNT_HW_CACHE_OP_READ << 8) | (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16));
+     task->l1i_counter_event_type = EVENT_PRE_HW_CACHE_L1I;
+
+     task->l1i_miss_counter_fd = perf_init_counter (PERF_TYPE_HW_CACHE, PERF_COUNT_HW_CACHE_L1I | (PERF_COUNT_HW_CACHE_OP_READ << 8) | (PERF_COUNT_HW_CACHE_RESULT_MISS << 16));
+     task->l1i_miss_counter_event_type = EVENT_PRE_HW_CACHE_L1I_MISS;
+
+     task->l1d_counter_fd = perf_init_counter (PERF_TYPE_HW_CACHE, PERF_COUNT_HW_CACHE_L1D | (PERF_COUNT_HW_CACHE_OP_READ << 8) | (PERF_COUNT_HW_CACHE_RESULT_ACCESS << 16));
+     task->l1d_counter_event_type = EVENT_PRE_HW_CACHE_L1D;
+
+     task->l1d_miss_counter_fd = perf_init_counter (PERF_TYPE_HW_CACHE, PERF_COUNT_HW_CACHE_L1D | (PERF_COUNT_HW_CACHE_OP_READ << 8) | (PERF_COUNT_HW_CACHE_RESULT_MISS << 16));
+     task->l1d_miss_counter_event_type = EVENT_PRE_HW_CACHE_L1D_MISS;
+
+     task->cache_misses_counter_fd = perf_init_counter (PERF_TYPE_HARDWARE, PERF_COUNT_HW_CACHE_MISSES);
+     task->cache_misses_counter_event_type = EVENT_PRE_HW_CACHE_MISSES;
+ 
+     task->instructions_counter_fd = perf_init_counter (PERF_TYPE_HARDWARE, PERF_COUNT_HW_INSTRUCTIONS);
+     task->instructions_counter_event_type = EVENT_PRE_HW_INSTRUCTIONS;
+ 
+     task->branch_misses_counter_fd = perf_init_counter (PERF_TYPE_SOFTWARE, PERF_COUNT_HW_BRANCH_MISSES);
+     task->branch_misses_counter_event_type = EVENT_PRE_HW_BRANCH_MISSES;
+ 
+     task->page_faults_counter_fd = perf_init_counter (PERF_TYPE_SOFTWARE, PERF_COUNT_SW_PAGE_FAULTS);
+     task->page_faults_counter_event_type = EVENT_PRE_THREAD_PAGE_FAULTS;
+ 
+     task->cpu_migrations_counter_fd = perf_init_counter (PERF_TYPE_SOFTWARE, PERF_COUNT_SW_CPU_MIGRATIONS);
+     task->cpu_migrations_counter_event_type = EVENT_PRE_THREAD_CPU_MIGRATIONS;
+     
+     task->ctx_switches_counter_fd = perf_init_counter (PERF_TYPE_SOFTWARE, PERF_COUNT_SW_CONTEXT_SWITCHES);
+     task->ctx_switches_counter_event_type = EVENT_PRE_THREAD_CTX_SWITCHES;
+
 }
 
 void perf_reset_counter(int fd) {
@@ -325,8 +357,39 @@ newTask (bool worker)
     task->spare_incalls = NULL;
     task->incall        = NULL;
     task->preferred_capability = -1;
-    task->counter_fd = -1;
-    task->counter_event_type = -1;
+
+    task->task_clock_counter_fd = -1;
+    task->task_clock_counter_event_type = -1;
+
+    task->l1i_counter_fd = -1;
+    task->l1i_counter_event_type = -1;
+
+    task->l1i_miss_counter_fd = -1;
+    task->l1i_miss_counter_event_type = -1;
+
+    task->l1d_counter_fd = -1;
+    task->l1d_counter_event_type = -1;
+
+    task->l1d_miss_counter_fd = -1;
+    task->l1d_miss_counter_event_type = -1;
+
+    task->cache_misses_counter_fd = -1;
+    task->cache_misses_counter_event_type = -1;
+
+    task->instructions_counter_fd = -1;
+    task->instructions_counter_event_type = -1;
+
+    task->branch_misses_counter_fd = -1;
+    task->branch_misses_counter_event_type = -1;
+
+    task->page_faults_counter_fd = -1;
+    task->page_faults_counter_event_type = -1;
+
+    task->cpu_migrations_counter_fd = -1;
+    task->cpu_migrations_counter_event_type = -1;
+
+    task->ctx_switches_counter_fd = -1;
+    task->ctx_switches_counter_event_type = -1;
 
 #if defined(THREADED_RTS)
     initCondition(&task->cond);

--- a/rts/Task.h
+++ b/rts/Task.h
@@ -157,8 +157,30 @@ typedef struct Task_ {
 
     // if >= 0, this Capability will be used for in-calls
     int preferred_capability;
-    int counter_fd;
-    int counter_event_type;
+
+    int task_clock_counter_fd;
+    int l1i_counter_fd;
+    int l1i_miss_counter_fd;
+    int l1d_counter_fd;
+    int l1d_miss_counter_fd;
+    int cache_misses_counter_fd;
+    int instructions_counter_fd;
+    int branch_misses_counter_fd;
+    int page_faults_counter_fd;
+    int cpu_migrations_counter_fd;
+    int ctx_switches_counter_fd;
+
+    int task_clock_counter_event_type;
+    int l1i_counter_event_type;
+    int l1i_miss_counter_event_type;
+    int l1d_counter_event_type;
+    int l1d_miss_counter_event_type;
+    int cache_misses_counter_event_type;
+    int instructions_counter_event_type;
+    int branch_misses_counter_event_type;
+    int page_faults_counter_event_type;
+    int cpu_migrations_counter_event_type;
+    int ctx_switches_counter_event_type;
 
     // Links tasks on the returning_tasks queue of a Capability, and
     // on spare_workers.


### PR DESCRIPTION
Added following perf  event counters

- L1i Cache Hit
- L1i Cache Miss
- L1d Cache Hit
- L1d Cache Miss
- Last Level Cache Misses
- Instructions
- Branch Misses
- Thread Page Fault Minor
- Thread CPU Migrations
- Thread Allocated

